### PR TITLE
Error render en index fixed

### DIFF
--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -1,5 +1,3 @@
-import { type } from 'os';
-
 const axios = require('axios')
 export const GET_ALL_BOOKS = 'GET_ALL_BOOKS';
 export const GET_BOOK_DETAIL = 'GET_BOOK_DETAIL'

--- a/client/src/components/Home/Home.jsx
+++ b/client/src/components/Home/Home.jsx
@@ -2,17 +2,17 @@ import React from "react";
 import { useDispatch } from "react-redux";
 import Card from "../Card/Card";
 import Style from "./Home.module.css";
-import {sortOfList, filterByCategory} from '../../actions/index'
+import { sortOfList, filterByCategory } from '../../actions/index'
 
 function Home(props) {
-const dispatch = useDispatch()
-const [order, setOrder]= React.useState("")
-  function handlerByCategory(e){
-  dispatch(filterByCategory(e.target.value))
+  const dispatch = useDispatch()
+  const [order, setOrder] = React.useState("")
+  function handlerByCategory(e) {
+    dispatch(filterByCategory(e.target.value))
   }
-  function handlerOrder(e){
-  dispatch(sortOfList(e.target.value))
-  setOrder(`Order ${e.target.value}`)
+  function handlerOrder(e) {
+    dispatch(sortOfList(e.target.value))
+    setOrder(`Order ${e.target.value}`)
   }
   return (
     <div className={Style.home_container}>
@@ -21,7 +21,7 @@ const [order, setOrder]= React.useState("")
       {/* *aqui iria la searchbar* */}
       <ul className={Style.filter_container}>
         <li>
-          Filter : 
+          Filter :
           <select onChange={handlerByCategory}>
             <option disabled>select gender</option>
             <option value="terror">Horror</option>

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,32 +1,63 @@
 import React from "react";
-import ReactDOM from "react-dom/client";
+import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./App";
-import reportWebVitals from "./reportWebVitals";
 import { Auth0Provider } from "@auth0/auth0-react";
 import { Provider } from "react-redux";
 import { store } from "./store/index";
 
-const root = ReactDOM.createRoot(document.getElementById("root"));
 const domain = process.env.REACT_APP_AUTH0_DOMAIN;
 const clientId = process.env.REACT_APP_AUTH0_CLIENT_ID;
-console.log(window.location); // redireccionar al Home
-root.render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <Auth0Provider
-        domain={domain}
-        clientId={clientId}
-        redirectUri={window.location.origin}
-      >
-        <App />
-      </Auth0Provider>
-    
-    </Provider>
-  </React.StrictMode>
+
+ReactDOM.render(
+  <Provider store={store}>
+    <Auth0Provider
+      domain={domain}
+      clientId={clientId}
+      redirectUri={window.location.origin}
+    >
+      <App />
+    </Auth0Provider>    
+  </Provider>,
+  document.getElementById("root")
 );
 
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();
+
+
+// No funciona con React.StricMode
+
+// import React from "react";
+// import ReactDOM from "react-dom/client";
+// import "./index.css";
+// import App from "./App";
+// import reportWebVitals from "./reportWebVitals";
+// import { BrowserRouter } from "react-router-dom";
+// import { Auth0Provider } from "@auth0/auth0-react";
+// import { Provider } from "react-redux";
+// import { store } from "./store/index";
+
+// const root = ReactDOM.createRoot(document.getElementById("root"));
+// const domain = process.env.REACT_APP_AUTH0_DOMAIN;
+// const clientId = process.env.REACT_APP_AUTH0_CLIENT_ID;
+// console.log(window.location); // redireccionar al Home
+// root.render(
+//   <React.StrictMode>  
+//     <BrowserRouter>
+//       <Provider store={store}>
+//         <Auth0Provider
+//           domain={domain}
+//           clientId={clientId}
+//           redirectUri={window.location.origin}
+//         >
+//           <App />
+//         </Auth0Provider>
+//       </Provider>
+//     </BrowserRouter>
+//   </React.StrictMode>
+// );
+
+// // If you want to start measuring performance in your app, pass a function
+// // to log results (for example: reportWebVitals(console.log))
+// // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
+// reportWebVitals();
+


### PR DESCRIPTION
React.StrictMode fue retirado de index.js debido a que ocasionaba fallos de renderización de algunos componentes al intentar ser mostrados usando el Nav u otros botones.

Según fuentes, ya que proyecto tiene una versión de React 18.2.0, el Strict mode no es necesario, ya que en esta versión fue reemplazado por otras mejoras en React, aunque es importante y sería lo ideal tenerlo.